### PR TITLE
Removed ActionBar and moved Settings to Header, Using Translucent Status/NavBar in API-19

### DIFF
--- a/Rebuild/build.gradle
+++ b/Rebuild/build.gradle
@@ -29,12 +29,12 @@ def gitSha() {
 }
 
 android {
-    compileSdkVersion 18
+    compileSdkVersion 19
     buildToolsVersion "19.0.1"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 18
+        targetSdkVersion 19
         versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
         versionName "${versionMajor}.${versionMinor}.${versionPatch}-${gitSha()}"
     }

--- a/Rebuild/src/main/AndroidManifest.xml
+++ b/Rebuild/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="18" />
+        android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/AboutActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/AboutActivity.java
@@ -1,7 +1,10 @@
 package rejasupotaro.rebuild.activities;
 
 import android.app.ActionBar;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
+import android.util.TypedValue;
 import android.view.MenuItem;
 import android.widget.ListView;
 
@@ -12,8 +15,10 @@ import javax.inject.Inject;
 
 import rejasupotaro.rebuild.R;
 import rejasupotaro.rebuild.adapters.AboutItemListAdapter;
+import rejasupotaro.rebuild.listener.NotificationEpisodesCheckBoxChangeListener;
 import rejasupotaro.rebuild.models.AboutItem;
 import rejasupotaro.rebuild.tools.MenuDelegate;
+import rejasupotaro.rebuild.utils.PreferenceUtils;
 import rejasupotaro.rebuild.utils.ViewUtils;
 import rejasupotaro.rebuild.views.RecentChangesView;
 import roboguice.inject.InjectView;
@@ -67,10 +72,34 @@ public class AboutActivity extends RoboActionBarActivity {
 
         AboutItemListAdapter adapter = new AboutItemListAdapter(this, aboutItemList);
         aboutItemListView.setAdapter(adapter);
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            aboutItemListView.setPadding(0, getStatusbarHeight() + getActionbarHeight(), 0, 0);
+        }
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         return menuDelegate.onItemSelect(item);
+    }
+
+    private int getStatusbarHeight() {
+        Resources resources = getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
+    }
+
+    private int getActionbarHeight() {
+        int actionBarHeight = 0;
+        TypedValue tv = new TypedValue();
+        if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+            actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+        }
+        return actionBarHeight;
     }
 }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/EpisodeDetailActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/EpisodeDetailActivity.java
@@ -45,8 +45,7 @@ public class EpisodeDetailActivity extends RoboActionBarActivity {
 
     private void setupActionBar() {
         ActionBar actionBar = getActionBar();
-        actionBar.setDisplayHomeAsUpEnabled(true);
-        actionBar.setHomeButtonEnabled(true);
+        actionBar.hide();
     }
 
     @Override

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/LicensesActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/LicensesActivity.java
@@ -1,8 +1,11 @@
 package rejasupotaro.rebuild.activities;
 
 import android.app.ActionBar;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.MenuItem;
+import android.view.View;
 import android.webkit.WebView;
 
 import javax.inject.Inject;
@@ -38,10 +41,36 @@ public class LicensesActivity extends RoboActionBarActivity {
     private void setupLicensesView() {
         licensesView.getSettings().setJavaScriptEnabled(false);
         licensesView.loadUrl(LICENSES_FILE_PATH);
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            View view = findViewById(R.id.licenses_view_container);
+            view.setPadding(0, getStatusbarHeight() + getActionbarHeight(), 0, 0);
+        }
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         return menuDelegate.onItemSelect(item);
     }
+
+    private int getStatusbarHeight() {
+        Resources resources = getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
+    }
+
+    private int getActionbarHeight() {
+        int actionBarHeight = 0;
+        TypedValue tv = new TypedValue();
+        if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+            actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+        }
+        return actionBarHeight;
+    }
+
 }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/MainActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/MainActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 
 import javax.inject.Inject;
 
@@ -34,6 +35,10 @@ public class MainActivity extends RoboActionBarActivity
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        //Hide actionbar
+        getActionBar().hide();
+
         startServices();
         parseIntent(getIntent());
     }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/SettingsActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/SettingsActivity.java
@@ -3,9 +3,11 @@ package rejasupotaro.rebuild.activities;
 import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.PreferenceActivity;
+import android.util.TypedValue;
 import android.view.MenuItem;
 
 import rejasupotaro.rebuild.R;
@@ -33,6 +35,13 @@ public class SettingsActivity extends PreferenceActivity {
         actionBar.setDisplayHomeAsUpEnabled(true);
         actionBar.setHomeButtonEnabled(true);
         setUpNotificationEpisodesCheckBox();
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            getListView().setPadding(0, getStatusbarHeight() + getActionbarHeight(), 0, 0);
+        }
+
     }
 
     @Override
@@ -46,6 +55,24 @@ public class SettingsActivity extends PreferenceActivity {
         boolean checkStatus = PreferenceUtils.getBoolean(this, key);
         checkBox.setChecked(checkStatus);
         checkBox.setOnPreferenceChangeListener(new NotificationEpisodesCheckBoxChangeListener(this));
+    }
+
+    private int getStatusbarHeight() {
+        Resources resources = getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
+    }
+
+    private int getActionbarHeight() {
+        int actionBarHeight = 0;
+        TypedValue tv = new TypedValue();
+        if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+            actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+        }
+        return actionBarHeight;
     }
 
 }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/activities/TimelineActivity.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/activities/TimelineActivity.java
@@ -3,7 +3,9 @@ package rejasupotaro.rebuild.activities;
 import android.app.ActionBar;
 import android.app.LoaderManager;
 import android.content.Loader;
+import android.content.res.Resources;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -82,6 +84,12 @@ public class TimelineActivity extends RoboActionBarActivity {
         });
 
         requestTweetList();
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            tweetListView.setPadding(0, getStatusbarHeight() + getActionbarHeight(), 0, 0);
+        }
     }
 
     private boolean isFirstRequest = true;
@@ -115,14 +123,21 @@ public class TimelineActivity extends RoboActionBarActivity {
         tweetListAdapter.addAll(tweetList);
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.main, menu);
-        return true;
+    private int getStatusbarHeight() {
+        Resources resources = getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        return menuDelegate.onItemSelect(item);
+    private int getActionbarHeight() {
+        int actionBarHeight = 0;
+        TypedValue tv = new TypedValue();
+        if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+            actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+        }
+        return actionBarHeight;
     }
 }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/fragments/EpisodeListFragment.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/fragments/EpisodeListFragment.java
@@ -2,6 +2,7 @@ package rejasupotaro.rebuild.fragments;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +15,7 @@ import com.google.inject.Inject;
 import java.util.List;
 
 import rejasupotaro.rebuild.R;
+import rejasupotaro.rebuild.activities.SettingsActivity;
 import rejasupotaro.rebuild.activities.TimelineActivity;
 import rejasupotaro.rebuild.adapters.EpisodeListAdapter;
 import rejasupotaro.rebuild.api.RssFeedClient;
@@ -53,7 +55,7 @@ public class EpisodeListFragment extends RoboFragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+                             Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_episode_list, null);
         return view;
     }
@@ -100,6 +102,23 @@ public class EpisodeListFragment extends RoboFragment {
                     }
                 });
 
+        FontAwesomeTextView settingsText = (FontAwesomeTextView) header.findViewById(R.id.link_text_settings);
+        settingsText.prepend(FontAwesomeTextView.Icon.SETTINGS);
+        settingsText.findViewById(R.id.link_text_settings).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        startActivity(new Intent(getActivity(), SettingsActivity.class));
+                    }
+                });
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            View view = header.findViewById(R.id.episode_list_header);
+            view.getLayoutParams().height += getStatusbarHeight();
+        }
+
         ViewUtils.addHeaderView(episodeListView, header);
     }
 
@@ -112,6 +131,16 @@ public class EpisodeListFragment extends RoboFragment {
                 IntentUtils.openMiyagawaProfile(getActivity());
             }
         });
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            if (getResources().getBoolean(R.bool.translucentNavBar))
+            {
+                View view = footer.findViewById(R.id.sf_text);
+                view.setPadding(0, 0, 0, getNavigationbarHeight());
+            }
+        }
 
         episodeListView.addFooterView(footer, null, false);
     }
@@ -144,5 +173,23 @@ public class EpisodeListFragment extends RoboFragment {
     public void setupEpisodeListView(List<Episode> episodeList) {
         EpisodeListAdapter episodeListAdapter = new EpisodeListAdapter(getActivity(), episodeList);
         episodeListView.setAdapter(episodeListAdapter);
+    }
+
+    private int getStatusbarHeight() {
+        Resources resources = getActivity().getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
+    }
+
+    private int getNavigationbarHeight() {
+        Resources resources = getActivity().getResources();
+        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
     }
 }

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/views/EpisodeDetailHeaderView.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/views/EpisodeDetailHeaderView.java
@@ -4,6 +4,7 @@ import com.squareup.otto.Subscribe;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -108,6 +109,12 @@ public class EpisodeDetailHeaderView extends LinearLayout {
         setupShareButton(episode);
         setupDownloadButton(episode);
         setupSeekBar(episode);
+
+        int SDK_INT = android.os.Build.VERSION.SDK_INT;
+        if (SDK_INT >= 19) {
+            //In SDK4.4~, it has translucent navigation bar and status bar
+            episodeTitleTextView.setPadding(0, getStatusbarHeight(), 0, 0);
+        }
     }
 
     private void setupMediaPlayAndPauseButton(final Episode episode) {
@@ -285,6 +292,15 @@ public class EpisodeDetailHeaderView extends LinearLayout {
                 mediaStartAndPauseButton.setChecked(false);
             }
         });
+    }
+
+    private int getStatusbarHeight() {
+        Resources resources = getResources();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
     }
 }
 

--- a/Rebuild/src/main/java/rejasupotaro/rebuild/views/FontAwesomeTextView.java
+++ b/Rebuild/src/main/java/rejasupotaro/rebuild/views/FontAwesomeTextView.java
@@ -44,6 +44,7 @@ public class FontAwesomeTextView extends TextView {
         TRASH(0xF014),
         MINUS(0xF146),
         SPINNER(0xF110),
+        SETTINGS(0xF013),
         SHARE(0xF045);
 
         private int unicode;

--- a/Rebuild/src/main/res/layout/activity_licenses.xml
+++ b/Rebuild/src/main/res/layout/activity_licenses.xml
@@ -4,6 +4,7 @@
         android:gravity="center"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:id="@+id/licenses_view_container"
         >
     <WebView
             android:id="@+id/licenses_view"

--- a/Rebuild/src/main/res/layout/footer_episode_list.xml
+++ b/Rebuild/src/main/res/layout/footer_episode_list.xml
@@ -5,7 +5,7 @@
         android:padding="@dimen/padding_contents"
         android:gravity="center"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         >
     <LinearLayout
             android:orientation="horizontal"
@@ -31,6 +31,7 @@
 
     </LinearLayout>
     <TextView
+            android:id="@+id/sf_text"
             android:text="in San Francisco, CA."
             android:textSize="@dimen/quaternary_text_size"
             android:textColor="@color/gray"

--- a/Rebuild/src/main/res/layout/header_episode_detail.xml
+++ b/Rebuild/src/main/res/layout/header_episode_detail.xml
@@ -6,13 +6,16 @@
         >
     <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="240dp"
             >
+
         <ImageView
-                android:background="@drawable/miyagawa_in_yapc"
-                android:layout_width="match_parent"
-                android:layout_height="240dp"
-                />
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+
+            android:src="@drawable/miyagawa_in_yapc"
+            android:scaleType="centerCrop" />
+
         <FrameLayout
                 android:id="@+id/episode_detail_header_cover"
                 android:background="@color/smoke_black"

--- a/Rebuild/src/main/res/layout/header_episode_list.xml
+++ b/Rebuild/src/main/res/layout/header_episode_list.xml
@@ -3,9 +3,15 @@
     android:layout_height="wrap_content">
 
     <RelativeLayout
-        android:background="@drawable/bg_rebuild"
+        android:id="@+id/episode_list_header"
         android:layout_width="match_parent"
         android:layout_height="160dp">
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:src="@drawable/bg_rebuild"
+            android:scaleType="centerCrop" />
 
         <LinearLayout
             android:orientation="vertical"
@@ -26,11 +32,19 @@
         </LinearLayout>
 
         <rejasupotaro.rebuild.views.FontAwesomeTextView
-            android:id="@+id/link_text_twitter"
-            android:text="@string/label_timeline"
+            android:id="@+id/link_text_settings"
+            android:text="@string/label_settings"
             android:layout_marginRight="@dimen/padding_contents"
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
+            style="@style/HeaderLinkText" />
+
+        <rejasupotaro.rebuild.views.FontAwesomeTextView
+            android:id="@+id/link_text_twitter"
+            android:text="@string/label_timeline"
+            android:layout_toLeftOf="@+id/link_text_settings"
+            android:layout_marginRight="6dp"
+            android:layout_alignParentBottom="true"
             style="@style/HeaderLinkText" />
 
         <rejasupotaro.rebuild.views.FontAwesomeTextView

--- a/Rebuild/src/main/res/values-land-v19/bools.xml
+++ b/Rebuild/src/main/res/values-land-v19/bools.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="translucentNavBar">false</bool>
+</resources>

--- a/Rebuild/src/main/res/values-sw600dp-land-v19/bools.xml
+++ b/Rebuild/src/main/res/values-sw600dp-land-v19/bools.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="translucentNavBar">true</bool>
+</resources>

--- a/Rebuild/src/main/res/values-v19/bools.xml
+++ b/Rebuild/src/main/res/values-v19/bools.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="translucentNavBar">true</bool>
+</resources>

--- a/Rebuild/src/main/res/values-v19/styles.xml
+++ b/Rebuild/src/main/res/values-v19/styles.xml
@@ -1,0 +1,96 @@
+<resources>
+
+    <style name="RebuildTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:windowAnimationStyle">@style/SlideWindowAnimationStyle</item>
+        <item name="android:windowTranslucentNavigation">@bool/translucentNavBar</item>
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+
+    <style name="SlideWindowAnimationStyle"
+           parent="android:Animation.Activity">
+        <item name="android:activityOpenEnterAnimation">@anim/slide_open_enter</item>
+        <item name="android:activityOpenExitAnimation">@anim/slide_open_exit</item>
+        <item name="android:activityCloseEnterAnimation">@anim/slide_close_enter</item>
+        <item name="android:activityCloseExitAnimation">@anim/slide_close_exit</item>
+    </style>
+
+    <style name="RebuildLogText">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:shadowDx">8</item>
+        <item name="android:shadowDy">8</item>
+        <item name="android:shadowRadius">8</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="HeaderLinkText">
+        <item name="android:textSize">@dimen/quaternary_text_size</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:background">@drawable/bg_header_link_text</item>
+        <item name="android:padding">@dimen/padding_contents</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_width">96dp</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="ActionButton">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/base_color_gray</item>
+        <item name="android:background">@drawable/action_button_border</item>
+        <item name="android:layout_margin">@dimen/padding_frame</item>
+        <item name="android:padding">@dimen/padding_contents</item>
+        <item name="android:layout_gravity">right</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="DialogButtonText">
+        <item name="android:textSize">@dimen/primary_text_size</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:padding">@dimen/padding_contents</item>
+        <item name="android:gravity">center</item>
+        <item name="android:background">@drawable/bg_clickable</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="AboutListItemHeader">
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/tertiary_text_size</item>
+        <item name="android:padding">@dimen/padding_contents</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="ProfileImage">
+        <item name="android:layout_width">@dimen/profile_image_size</item>
+        <item name="android:layout_height">@dimen/profile_image_size</item>
+    </style>
+
+    <style name="AboutListItemText">
+        <item name="android:layout_marginLeft">@dimen/padding_contents</item>
+        <item name="android:textSize">@dimen/tertiary_text_size</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="Theme.Transparent" parent="android:Theme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
+    <style name="MediaStartAndPauseButton" parent="android:Widget.CompoundButton.CheckBox">
+        <item name="android:button">@drawable/media_start_and_pause_button</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+</resources>

--- a/Rebuild/src/main/res/values/strings.xml
+++ b/Rebuild/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
 
     <string name="label_timeline">timeline</string>
 
+    <string name="label_settings">settings</string>
+
     <string name="default_duration">00:00</string>
     <string name="share_episode">Share Episode</string>
 


### PR DESCRIPTION
こんにちは、松田(@hak)と申します。AndroidTeamでエンジニアをしています。
Rebuild.fm Viewer公開ありがとうございます。

試しにAPI-19のTranslucentNavBar/StatusBarに対応してみましたので、pull request送ります。いかがでしょうか？
主な変更点としては
- ActionBar項目がSettingsメニューだけだったため、MainActivityのHeaderMenuに統合してみました
  #今後ActionBar項目を増やしたい場合に問題が出る可能性もありますが、TranslucentStatusBarのデザインとActionBarの収まりが悪いため悩ましいところです。。
- API-19の場合に、TranslucentNavBar/StatusBarに合わせてPaddingの調整
  　getStatusbarHeight(), getNavigationbarHeight()が複数定義されてるため統合したほうが良いかもしれません。
  　API levelチェックが増えたため、可読性が落ちてしまっています。:(

よろしくお願いします。
